### PR TITLE
AGREGAR API_KEY a lista-videojuegos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secret.js

--- a/pages/lista-videojuegos/index.js
+++ b/pages/lista-videojuegos/index.js
@@ -1,1 +1,2 @@
 // JS Videojuegos.html
+import { API_KEY } from "../../secret";


### PR DESCRIPTION
Se agrega la API_KEY para el manejo de la API de Videojuegos. Por ahora, únicamente es importada en index.js de la page lista-videojuegos.